### PR TITLE
fix: test against `author` field

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -46,11 +46,11 @@ impl FeedQuery {
         }
 
         if let Some(author_reject) = &self.author_reject {
-            accepted &= !author_reject.0.is_match(&item.title);
+            accepted &= !author_reject.0.is_match(&item.author);
         }
 
         if let Some(author_allow) = &self.author_allow {
-            accepted &= author_allow.0.is_match(&item.title);
+            accepted &= author_allow.0.is_match(&item.authoer);
         }
 
         if let Some(url_reject) = &self.url_reject {


### PR DESCRIPTION
Great thx for hosting such a service. I've been using it for a while now, and it works like a charm. But there's a little typo that the `author` regex is filtered against the `title` field instead.